### PR TITLE
[feature] automate PyPi package publishing with GitHub Actions

### DIFF
--- a/.github/workflows/publish-package-on-release.yaml
+++ b/.github/workflows/publish-package-on-release.yaml
@@ -1,0 +1,25 @@
+name: Publish package
+
+on:
+  release:
+    types: [published]
+    
+jobs:
+  build:
+    name: Publish package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:         
+          python-version: '3.8'
+      - name: Install dependencies
+        run: |
+          pip install poetry poetry-dynamic-versioning
+      - name: Publish package on pypi
+        run: |
+          poetry build
+          poetry publish -u ${{ secrets.PYPI_USERNAME }} -p ${{ secrets.PYPI_PASSWORD }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,5 +24,8 @@ numpy = "^1.19.2"
 [tool.poetry.dev-dependencies]
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.poetry-dynamic-versioning]
+enable = true


### PR DESCRIPTION
I create a workflow to automate the pypi package publishing on a github release. Now, every time you create a release on github, the package will be published in pypi with the release tag. Of course, I need to create two secret variables:
 - `PYPI_USERNAME` : with your pypi username as value
 - `PYPI_PASSWORD`: with your pypi password as value