### PR TITLE
fix: use admin PAT for semantic-release push to bypass PR rule

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,12 +17,13 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
+        token: ${{ secrets.RELEASE_TOKEN }}
 
     - name: Python Semantic Release
       id: release
       uses: python-semantic-release/python-semantic-release@v9.21.0
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        github_token: ${{ secrets.RELEASE_TOKEN }}
 
     - uses: astral-sh/setup-uv@v8.3.2
       if: steps.release.outputs.released == 'true'


### PR DESCRIPTION
## Problem
The "Require a pull request before merging" ruleset on master blocks
python-semantic-release's direct push of the version bump commit and
tag, which uses GITHUB_TOKEN.

## Fix
checkout and the python-semantic-release step now use RELEASE_TOKEN
(a PAT from an account added to the ruleset's bypass list), so the
release commit goes through without weakening the rule for regular
contributors.