### PR TITLE
fix: relax tabulate version constraint to allow 0.9.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 dependencies = [
     "numpy>=1.21.1,<2",
-    "tabulate>=0.8.9,<0.9",
+    "tabulate>=0.8.9,<1",
     "tqdm>=4.64.1,<5",
     "joblib>=1.2.0,<2",
     "pydantic>=2.6.4,<3",

--- a/uv.lock
+++ b/uv.lock
@@ -1474,7 +1474,7 @@ wheels = [
 
 [[package]]
 name = "fuzzy-c-means"
-version = "1.7.2"
+version = "1.7.3"
 source = { editable = "." }
 dependencies = [
     { name = "joblib" },
@@ -1514,7 +1514,7 @@ requires-dist = [
     { name = "joblib", specifier = ">=1.2.0,<2" },
     { name = "numpy", specifier = ">=1.21.1,<2" },
     { name = "pydantic", specifier = ">=2.6.4,<3" },
-    { name = "tabulate", specifier = ">=0.8.9,<0.9" },
+    { name = "tabulate", specifier = ">=0.8.9,<1" },
     { name = "tqdm", specifier = ">=4.64.1,<5" },
     { name = "typer", specifier = ">=0.9.0,<0.10" },
 ]


### PR DESCRIPTION
## Summary
- Relaxes the `tabulate` dependency from `>=0.8.9,<0.9` to `>=0.8.9,<1`.
- `pandas` requires `tabulate>=0.9.0` when installed with the
  `output-formatting`/`all` extras (used for `df.to_markdown()`),
  which conflicted with our hard `<0.9` upper bound.
- `tabulate`'s `tabulate()` API used in `fcmeans/cli.py` (fancy_grid
  format) is unaffected by the 0.9.0 bump.

Fixes #109

## Test plan
- [ ] `uv lock`
- [ ] `uv run pytest --cov=fcmeans`