### PR TITLE
fix: allow datasets containing 0.0 values in CLI

### DIFF
--- a/fcmeans/cli.py
+++ b/fcmeans/cli.py
@@ -67,15 +67,14 @@ def _read_data(dataset_path, delimiter, quiet):
     if not quiet:
         typer.echo("Reading data set... ", nl=False)
     X = np.genfromtxt(dataset_path, delimiter=delimiter)
-    # Check file read
-    if not np.all(X):
-        typer.echo(
-            "Error: Please verify if value for '--delimiter' / '-d' is "
-            f"the delimiter of the '{dataset_path}' file."
-        )
-        raise typer.Abort()
+    # A wrong delimiter makes genfromtxt produce NaN, so the NaN check below
+    # also catches delimiter mistakes.
     if np.isnan(np.sum(X)):
-        typer.echo(f"Error: File '{dataset_path}' cannot contain NaN.")
+        typer.echo(
+            f"Error: File '{dataset_path}' contains NaN. Verify that the "
+            "value for '--delimiter' / '-d' matches the file's delimiter "
+            "and that the file has no missing values."
+        )
         raise typer.Abort()
     if not quiet:
         typer.echo("Data set read without errors...")


### PR DESCRIPTION
## Summary
- `fcm fit`/`fcm predict` aborted with a "wrong delimiter" error on any   CSV containing a legitimate `0.0` value, because `_read_data` checked  `np.all(X)`, which is `False` whenever any element is `0`.
- That check never served its intended purpose either: a wrong  delimiter makes `np.genfromtxt` produce `NaN`, and `np.all` treats  `NaN` as truthy, so the check silently passed through the case it was meant to catch. The existing `np.isnan(np.sum(X))` check already catches both wrong-delimiter and NaN-data cases, so the redundant block was removed and its error message updated to cover both.

Fixes #114 

## Test plan
- [x] `uv run pytest --cov=fcmeans` passes
- [x] `fcm fit` on a CSV containing `0.0` now trains successfully (previously aborted)
- [x] `fcm fit` on a CSV with a genuinely wrong delimiter still aborts, via the NaN check
- [x] `black --check` / `flake8` show no new issues on the diff