### PR TITLE
perf!: vectorize soft_predict and drop the joblib dependency

### DIFF
--- a/fcmeans/main.py
+++ b/fcmeans/main.py
@@ -110,17 +110,15 @@ class FCM(BaseModel):
         Returns:
             NDArray: Index of the cluster each sample belongs to.
         """
-        if self._is_trained():
-            X = np.expand_dims(X, axis=0) if len(X.shape) == 1 else X
-            return self.soft_predict(X).argmax(axis=-1)
-        raise ReferenceError(
-            "You need to train the model. Run `.fit()` method to this."
-        )
+        self._require_trained()
+        X = np.expand_dims(X, axis=0) if len(X.shape) == 1 else X
+        return self.soft_predict(X).argmax(axis=-1)
 
-    def _is_trained(self) -> bool:
-        if self.trained:
-            return True
-        return False
+    def _require_trained(self) -> None:
+        if not self.trained:
+            raise ReferenceError(
+                "You need to train the model. Run `.fit()` method to this."
+            )
 
     @staticmethod
     def _dist(
@@ -175,11 +173,8 @@ class FCM(BaseModel):
 
     @property
     def centers(self) -> NDArray:
-        if self._is_trained():
-            return self._centers
-        raise ReferenceError(
-            "You need to train the model. Run `.fit()` method to this."
-        )
+        self._require_trained()
+        return self._centers
 
     @property
     def partition_coefficient(self) -> float:
@@ -188,16 +183,10 @@ class FCM(BaseModel):
         Equation 12a of
         [this paper](https://doi.org/10.1016/0098-3004(84)90020-7).
         """
-        if self._is_trained():
-            return np.sum(np.mean(self.u**2, axis=0))
-        raise ReferenceError(
-            "You need to train the model. Run `.fit()` method to this."
-        )
+        self._require_trained()
+        return np.sum(np.mean(self.u**2, axis=0))
 
     @property
     def partition_entropy_coefficient(self):
-        if self._is_trained():
-            return -np.sum(np.mean(self.u * np.log2(self.u), axis=0))
-        raise ReferenceError(
-            "You need to train the model. Run `.fit()` method to this."
-        )
+        self._require_trained()
+        return -np.sum(np.mean(self.u * np.log2(self.u), axis=0))

--- a/fcmeans/main.py
+++ b/fcmeans/main.py
@@ -3,7 +3,6 @@ from typing import Callable, Dict, Optional, Union
 
 import numpy as np
 import tqdm
-from joblib import Parallel, delayed
 from numpy.typing import NDArray
 from pydantic import BaseModel, ConfigDict, Field, validate_call
 
@@ -49,7 +48,6 @@ class FCM(BaseModel):
     error: float = Field(1e-5, ge=1e-9)
     random_state: Optional[int] = None
     trained: bool = False
-    n_jobs: int = Field(1, ge=1)
     verbose: Optional[bool] = False
     distance: Optional[Union[DistanceOptions, Callable]] = (
         DistanceOptions.euclidean
@@ -97,14 +95,7 @@ class FCM(BaseModel):
             self.distance,
             self.distance_params
         ) ** (2 / (self.m - 1))
-        u_dist = Parallel(n_jobs=self.n_jobs)(
-            delayed(
-                lambda data, col: (data[:, col] / data.T).sum(0)
-            )(temp, col)
-            for col in range(temp.shape[1])
-        )
-        u_dist = np.vstack(u_dist).T
-        return 1 / u_dist
+        return 1.0 / (temp * (1.0 / temp).sum(axis=1, keepdims=True))
 
     @validate_call(config=dict(arbitrary_types_allowed=True))
     def predict(self, X: NDArray) -> NDArray:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ dependencies = [
     "numpy>=1.21.1,<2",
     "tabulate>=0.8.9,<1",
     "tqdm>=4.64.1,<5",
-    "joblib>=1.2.0,<2",
     "pydantic>=2.6.4,<3",
     "typer>=0.9.0,<0.10",
 ]

--- a/tests/test_fcm.py
+++ b/tests/test_fcm.py
@@ -19,7 +19,7 @@ def test_u_creation():
 def test_dont_fit():
     """Test if its returns Exceptions"""
     fcm = FCM()
-    assert fcm._is_trained() == False
+    assert fcm.trained == False
     with pytest.raises(ReferenceError):
         partition_entropy_coefficient = fcm.partition_entropy_coefficient
     with pytest.raises(ReferenceError):

--- a/tests/test_fcm.py
+++ b/tests/test_fcm.py
@@ -26,3 +26,29 @@ def test_dont_fit():
         partition_coefficient = fcm.partition_coefficient
     with pytest.raises(ReferenceError):
         centers = fcm.centers
+
+
+def test_u_rows_sum_to_one():
+    """Test if membership matrix rows are normalized"""
+    fcm = FCM(n_clusters=3, random_state=42)
+    fcm.fit(X)
+    assert np.allclose(fcm.u.sum(axis=1), 1.0)
+
+
+def test_soft_predict_matches_u_after_fit():
+    """Test if soft_predict(X) reproduces the fitted membership matrix"""
+    fcm = FCM(n_clusters=3, random_state=42)
+    fcm.fit(X)
+    assert np.allclose(fcm.soft_predict(X), fcm.u)
+
+
+def test_predict_shape_and_range():
+    """Test if predict returns one deterministic label per sample"""
+    n_clusters = 3
+    fcm = FCM(n_clusters=n_clusters, random_state=42)
+    fcm.fit(X)
+    labels = fcm.predict(X)
+    assert labels.shape == (X.shape[0],)
+    assert labels.min() >= 0
+    assert labels.max() < n_clusters
+    assert np.array_equal(labels, fcm.predict(X))

--- a/uv.lock
+++ b/uv.lock
@@ -1474,10 +1474,9 @@ wheels = [
 
 [[package]]
 name = "fuzzy-c-means"
-version = "1.7.3"
+version = "1.7.5"
 source = { editable = "." }
 dependencies = [
-    { name = "joblib" },
     { name = "numpy" },
     { name = "pydantic" },
     { name = "tabulate" },
@@ -1511,7 +1510,6 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "joblib", specifier = ">=1.2.0,<2" },
     { name = "numpy", specifier = ">=1.21.1,<2" },
     { name = "pydantic", specifier = ">=2.6.4,<3" },
     { name = "tabulate", specifier = ">=0.8.9,<1" },
@@ -1900,15 +1898,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
-]
-
-[[package]]
-name = "joblib"
-version = "1.5.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Vectorize `soft_predict`'s membership computation with a single numpy   expression, replacing the `joblib.Parallel` loop over clusters — same result, no pickling overhead for problems with only a handful of clusters.
- Drop the `joblib` dependency and the public `n_jobs` parameter entirely.
- Consolidate the duplicated `ReferenceError` "not trained" guard (repeated across `predict`, `centers`, `partition_coefficient`, `partition_entropy_coefficient`) into a single `_require_trained()` method.
- Add regression tests: `u` rows sum to 1, `soft_predict(X)` reproduces the fitted membership matrix, and `predict` returns deterministic, in-range labels.

## Breaking change
Removes the public `n_jobs` parameter. Low impact: `model_config` allows extra fields, so existing `FCM(n_jobs=...)` calls keep working — the kwarg is just silently ignored instead of doing anything. Should trigger a minor
version bump via semantic-release.

## Test plan
- [x] `uv run pytest --cov=fcmeans` — 5 passed, 84% coverage
- [x] `uv run flake8` / `uv run isort -c` clean on touched files
- [x] Verified `soft_predict` output is numerically identical (`np.allclose`) to the original joblib-based formula on a fixed `X`
- [x] `uv run fcm fit dataset.csv model.sav -c 3` still works end-to-end

Closes #116