### PR TITLE
fix: update readthedocs build os to ubuntu-24.04

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
     python: "3.9"
 


### PR DESCRIPTION
## Summary
- `ubuntu-20.04` was deprecated by Read the Docs, breaking the doc build with a config validation error (`build.os` must be one of ubuntu-22.04/24.04/26.04/ubuntu-lts-latest)
- Bump `.readthedocs.yaml` to `ubuntu-24.04`

## Test plan
- [ ] Confirm Read the Docs build succeeds after merge